### PR TITLE
Log JSON parse exception on invalid payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = async (req, res) => {
     payload = await json(req);
   } catch (e) {
     logger("err", "Missing JSON payload");
+    logger("err", e);
     return send(res, 400, "Missing JSON payload");
   }
 


### PR DESCRIPTION
## Summary

- Log the actual exception caught when parsing the JSON payload fails, in addition to the existing generic message
- The logger already handles both strings and objects (via `JSON.stringify`), so whatever the exception is (Error, string, object) it will be captured correctly

## Test plan

- [ ] Send a request with a missing or malformed JSON body and confirm the exception details appear in the log output alongside the `Missing JSON payload` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)