### PR TITLE
Log request when parsing fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { parse } = require("url");
 const { text, send } = require("micro");
 const logger = require("./lib/log");
 const runScript = require("./lib/run-script");
@@ -8,7 +7,7 @@ const slackNotification = require("./lib/slack-notification");
 module.exports = async (req, res) => {
   const hooks = require("./config/hook");
   const { slackConfig } = require("./config/config");
-  const { pathname } = await parse(req.url, false); // gets url path
+  const { pathname } = new URL(req.url, "http://dummy");
 
   if (pathname === "/ping") return send(res, 200, "pong");
 
@@ -17,15 +16,13 @@ module.exports = async (req, res) => {
     rawBody = await text(req);
     payload = JSON.parse(rawBody);
   } catch (e) {
-    logger("err", "Error parsing request:");
-    logger("err", e);
-    logger("err", {
+    logger("err", "Error parsing request:\n" + JSON.stringify({
       method: req.method,
       path: pathname,
       contentType: req.headers["content-type"],
       bodyLength: rawBody?.length,
       bodyPreview: rawBody?.slice(0, 200)
-    });
+    }));
     return send(res, 400, "Missing JSON payload");
   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { parse } = require("url");
-const { json, send } = require("micro");
+const { text, send } = require("micro");
 const logger = require("./lib/log");
 const runScript = require("./lib/run-script");
 const validateReq = require("./lib/validate-req");
@@ -12,18 +12,20 @@ module.exports = async (req, res) => {
 
   if (pathname === "/ping") return send(res, 200, "pong");
 
-  let payload;
+  let payload, rawBody;
   try {
-    logger("debug", {
-      method: req.method,
-      path: req.path,
-      contentType: req.headers["content-type"],
-      body: req.body
-    });
-    payload = await json(req);
+    rawBody = await text(req);
+    payload = JSON.parse(rawBody);
   } catch (e) {
-    logger("err", "Missing JSON payload");
+    logger("err", "Error parsing request:");
     logger("err", e);
+    logger("err", {
+      method: req.method,
+      path: pathname,
+      contentType: req.headers["content-type"],
+      bodyLength: rawBody?.length,
+      bodyPreview: rawBody?.slice(0, 200)
+    });
     return send(res, 400, "Missing JSON payload");
   }
 


### PR DESCRIPTION
Currently it was only logging method and content-type in every call, not useful:
```
backstage_hub-hook-handler.1.r29haesidy83@soundsystem-20190704    | [DEBUG] Thu, 04 Jun 2026 16:53:11 GMT hub-hook-handler: {"method":"POST","contentType":"application/json"}
```
**Note that** when parsing succeeds, the payload is printed, so this would be the same but when parsing fails.